### PR TITLE
support LWP version 6.* instead of only 6.0.*

### DIFF
--- a/lib/LWP/UserAgent/Patch/LogResponse.pm
+++ b/lib/LWP/UserAgent/Patch/LogResponse.pm
@@ -55,7 +55,7 @@ sub patch_data {
         patches => [
             {
                 action      => 'wrap',
-                mod_version => qr/^6\.0.*/,
+                mod_version => qr/^6\..*/,
                 sub_name    => 'simple_request',
                 code        => $p_simple_request,
             },


### PR DESCRIPTION
Hi,
I was unable to use your module with the current version of LWP (6.13) without this patch.

Enjoy,
Jon
